### PR TITLE
Add Windows Phone 8.1 & Universal Apps Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,7 +123,7 @@ publish/
 ## TODO: If you have NuGet Package Restore enabled, uncomment the next line
 packages/
 ## TODO: If the tool you use requires repositories.config, also uncomment the next line
-#!packages/repositories.config
+!packages/repositories.config
 
 # Windows Azure Build Output
 csx/
@@ -180,5 +180,4 @@ Desktop.ini
 # Recycle Bin used on file shares
 $RECYCLE.BIN/
 
-Smtpapi/packages/NUnit.2.6.3/license.txt
-Smtpapi/packages/NUnit.2.6.3/license.txt
+*.tss

--- a/Smtpapi/Smtpapi/SendGrid.SmtpApi.csproj
+++ b/Smtpapi/Smtpapi/SendGrid.SmtpApi.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>SendGrid.SmtpApi</RootNamespace>
     <AssemblyName>SendGrid.SmtpApi</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile136</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile328</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>


### PR DESCRIPTION
You will need to recompile, then add "+wpa81" to the end of the portable folder name in the NuGet package.
