### PR TITLE
Adds ability to set ASM Group ID to SMTPAPI Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.3.0] - 2015-2-6
+### Added
+- ASM Group ID setting
+
 ## [1.2.0] - 2015-1-26
 ### Added
 - This changelog. Nice.

--- a/Smtpapi/HeaderTests/TestHeader.cs
+++ b/Smtpapi/HeaderTests/TestHeader.cs
@@ -99,5 +99,14 @@ namespace SendGrid.SmtpApi.HeaderTests
             string result = test.JsonString();
             Assert.AreEqual("{\"to\" : [\"joe@example.com\", \"jane@example.com\"]}", result);
         }
+
+        [Test]
+        public void TestSetASMGroupID()
+        {
+            var test = new Header();
+            test.SetASMGroupID(123);
+            string result = test.JsonString();
+            Assert.AreEqual("{\asm_group_id\": 123", result);
+        }
     }
 }

--- a/Smtpapi/HeaderTests/TestHeader.cs
+++ b/Smtpapi/HeaderTests/TestHeader.cs
@@ -106,7 +106,7 @@ namespace SendGrid.SmtpApi.HeaderTests
             var test = new Header();
             test.SetASMGroupID(123);
             string result = test.JsonString();
-            Assert.AreEqual("{\asm_group_id\": 123", result);
+            Assert.AreEqual("{\"asm_group_id\" : 123}", result);
         }
     }
 }

--- a/Smtpapi/Smtpapi/Header.cs
+++ b/Smtpapi/Smtpapi/Header.cs
@@ -147,6 +147,17 @@ namespace SendGrid.SmtpApi
             _settings.AddArray(new List<string> {"to"}, addresses);
         }
 
+        /// <summary>
+        ///     This sets the ASM Group ID for this email.  You can find further documentation about ASM here:
+        ///     https://sendgrid.com/docs/API_Reference/Web_API_v3/Advanced_Suppression_Manager/index.html
+        /// </summary>
+        /// <param name="id">ASM group applied to the message</param>
+        public void SetASMGroupID(int id)
+        {
+            var keys = new List<string> { "asm_group_id" };
+            _settings.AddSetting(keys, id);
+        }
+
         #endregion
     }
 }

--- a/Smtpapi/Smtpapi/HeaderSettingsNode.cs
+++ b/Smtpapi/Smtpapi/HeaderSettingsNode.cs
@@ -12,7 +12,7 @@ namespace SendGrid.SmtpApi
 
         private readonly Dictionary<string, HeaderSettingsNode> _branches;
         private IEnumerable<string> _array;
-        private String _leaf;
+        private object _leaf;
 
         #endregion
 
@@ -41,7 +41,7 @@ namespace SendGrid.SmtpApi
             }
         }
 
-        public void AddSetting(List<String> keys, String value)
+        public void AddSetting(List<String> keys, object value)
         {
             if (keys.Count == 0)
             {
@@ -61,12 +61,12 @@ namespace SendGrid.SmtpApi
             }
         }
 
-        public String GetSetting(params String[] keys)
+        public object GetSetting(params String[] keys)
         {
             return GetSetting(keys.ToList());
         }
 
-        public String GetSetting(List<String> keys)
+        public object GetSetting(List<String> keys)
         {
             if (keys.Count == 0)
                 return _leaf;
@@ -93,7 +93,7 @@ namespace SendGrid.SmtpApi
             return _branches[key].GetArray(remainingKeys);
         }
 
-        public String GetLeaf()
+        public object GetLeaf()
         {
             return _leaf;
         }

--- a/Smtpapi/Smtpapi/IHeader.cs
+++ b/Smtpapi/Smtpapi/IHeader.cs
@@ -84,5 +84,12 @@ namespace SendGrid.SmtpApi
         /// </summary>
         /// <param name="addresses">List of email addresses</param>
         void SetTo(IEnumerable<string> addresses);
+
+        /// <summary>
+        ///     This sets the ASM Group ID for this email.  You can find further documentation about ASM here:
+        ///     https://sendgrid.com/docs/API_Reference/Web_API_v3/Advanced_Suppression_Manager/index.html
+        /// </summary>
+        /// <param name="id">ASM group applied to the message</param>
+        void SetASMGroupID(int id);
     }
 }

--- a/Smtpapi/Smtpapi/Properties/AssemblyInfo.cs
+++ b/Smtpapi/Smtpapi/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.CompilerServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.2.1.0")]
-[assembly: AssemblyFileVersion("1.2.1.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]


### PR DESCRIPTION
*Notes:*
1. I couldn't get this project to execute the unit tests without first:
  * Removing the `InternalsVisibleTo` setting in the AssemblyInfo.cs of Smtpapi project
  * Changing `HeaderSettingsNode` class from `internal` to `public`

2. I did not commit the change of changing HeaderSettingsNode from `internal` to `public`

3. Changed `_leaf` to an `object` rather than a `string` so any type can be set to it, this worked in testing but perhaps we want to restrict the acceptable types?