### PR TITLE
Added Newtonsoft.Json as a package dependency in the nuspec file.

### DIFF
--- a/Smtpapi/nuspec/SendGrid.SmtpApi.1.3.2.nuspec
+++ b/Smtpapi/nuspec/SendGrid.SmtpApi.1.3.2.nuspec
@@ -14,7 +14,7 @@
         <copyright>Copyright SendGrid, Inc. 2017</copyright>
         <tags>smtpapi sendgrid email</tags>
 		<dependencies>
-			<dependency id="Newtonsoft.Json" version="10.0.0" />
+			<dependency id="Newtonsoft.Json" version="9.0.0" />
 		</dependencies>
     </metadata>
     <files>

--- a/Smtpapi/nuspec/SendGrid.SmtpApi.1.3.2.nuspec
+++ b/Smtpapi/nuspec/SendGrid.SmtpApi.1.3.2.nuspec
@@ -13,6 +13,9 @@
         <releaseNotes />
         <copyright>Copyright SendGrid, Inc. 2017</copyright>
         <tags>smtpapi sendgrid email</tags>
+		<dependencies>
+			<dependency id="Newtonsoft.Json" version="10.0.0" />
+		</dependencies>
     </metadata>
     <files>
         <file src="lib\SendGrid.SmtpApi.dll" target="lib\SendGrid.SmtpApi.dll" />


### PR DESCRIPTION
Newtonsoft.Json version 10.0.0 (minimum version) is set as package dependency in the nuspec file.