### PR TITLE
chore: manually bump version number

### DIFF
--- a/Smtpapi/Smtpapi/SendGrid.SmtpApi.csproj
+++ b/Smtpapi/Smtpapi/SendGrid.SmtpApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.3.9</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <IsPackable>true</IsPackable>
     <TargetFrameworks>netstandard1.3;netstandard2.0;net452;net40</TargetFrameworks>
     <PlatformTarget>anycpu</PlatformTarget>


### PR DESCRIPTION
Version number was not bumped properly during release process.

Related PR to fix automatic version bump in librarian: https://code.hq.twilio.com/twilio/librarian/pull/275